### PR TITLE
FIX: restricting det to floating tipes for compatibility

### DIFF
--- a/ceygen/lu.pxd
+++ b/ceygen/lu.pxd
@@ -9,4 +9,4 @@ from dtype cimport dtype, nonint_dtype
 cdef nonint_dtype[:, :] inv(nonint_dtype[:, :] x, nonint_dtype[:, :] out = *) nogil
 cdef bint iinv(nonint_dtype[:, :] x) nogil except False
 
-cdef dtype det(dtype[:, :] x) nogil except *
+cdef nonint_dtype det(nonint_dtype[:, :] x) nogil except *

--- a/ceygen/lu.pyx
+++ b/ceygen/lu.pyx
@@ -53,16 +53,16 @@ cdef bint iinv(nonint_dtype[:, :] x) nogil except False:
 
 
 cdef void det_worker(
-        dtype *x_data, Py_ssize_t *x_shape, Py_ssize_t *x_strides, XMatrixContiguity x_dummy,
-        dtype *o) nogil:
-    cdef MatrixMap[dtype, XMatrixContiguity] x
+        nonint_dtype *x_data, Py_ssize_t *x_shape, Py_ssize_t *x_strides, XMatrixContiguity x_dummy,
+        nonint_dtype *o) nogil:
+    cdef MatrixMap[nonint_dtype, XMatrixContiguity] x
     x.init(x_data, x_shape, x_strides)
     o[0] = x.determinant()
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef dtype det(dtype[:, :] x) nogil except *:
-    cdef MSDispatcher[dtype] dispatcher
-    cdef dtype out
+cdef nonint_dtype det(nonint_dtype[:, :] x) nogil except *:
+    cdef MSDispatcher[nonint_dtype] dispatcher
+    cdef nonint_dtype out
     dispatcher.run(&x[0, 0], x.shape, x.strides, &out, det_worker, det_worker, det_worker)
     return out


### PR DESCRIPTION
More modern versions of Eigen (like 3.2.5) throw an static assert
if you try to compile the determinant of integer matrices.

Closes #5 
